### PR TITLE
Create testchild.py

### DIFF
--- a/testchild.py
+++ b/testchild.py
@@ -1,0 +1,2 @@
+language = "python"                                
+reversed_language = language[::-1]                                                                 print(reversed_language) # nohtyp


### PR DESCRIPTION
Less strings Python ne supporte pas la méthode intégreée reverse() comme le font les autres conteneurs Python comme list. Il existe de nombreuses approches pour inverser une chaîne de caractères (string), la plus simple étant d’utiliser l’opérateur de découpage (ou slicing).